### PR TITLE
fix requires symfony/process 6.4.3 with Caret Version Range

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "ext-zip": "*",
         "ext-xml": "*",
         "ext-gd": "*",
-        "symfony/process": "6.4.3",
+        "symfony/process": "^6.4.3",
         "phpoffice/phpspreadsheet": "^1.23",
         "phpoffice/phpword": "^0.18",
         "laravel/framework": "^10.0",


### PR DESCRIPTION
Hello,
I figure out on newer installations (Laravel 10.x) when I try to install "dev-master" I got this error:

"dev-master requires symfony/process 6.4.3 -> found symfony/process[v6.4.3] but the package is fixed to v6.4.4"

I modify the package requirements to "^6.4.3" .

```
composer require nilgems/laravel-textract:dev-master
./composer.json has been updated
Running composer update nilgems/laravel-textract
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires nilgems/laravel-textract dev-master -> satisfiable by nilgems/laravel-textract[dev-master].
    - nilgems/laravel-textract dev-master requires symfony/process 6.4.3 -> found symfony/process[v6.4.3] but the package is fixed to v6.4.4 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

